### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Export configuration for release archives
+# Include only the ide_rules folder and essential files
+
+# Exclude everything by default from "git archive"
+* export-ignore
+
+# Explicitly include desired items for releases
+ide_rules/ -export-ignore
+ide_rules/** -export-ignore
+README.md -export-ignore 


### PR DESCRIPTION
This pull request updates the `.gitattributes` file to improve how release archives are created. The main change is to exclude all files from `git archive` by default, except for the `ide_rules` folder and the `README.md` file, which are now explicitly included.

Release archive configuration:

* Exclude all files from `git archive` by default using the `export-ignore` attribute.
* Explicitly include the `ide_rules` folder and its contents, as well as `README.md`, in release archives by overriding the default exclusion.