### PR TITLE
Adding stale issue github action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,59 @@
+---
+    # This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+    # For more information, see: https://github.com/actions/stale
+    name: 'Close Stale Issues and PRs'
+    
+    on:
+      schedule:
+        # Runs at 02:33 UTC every day. You can adjust the schedule as needed.
+        - cron: '33 2 * * *'
+    
+    jobs:
+      stale:
+        # The type of runner that the job will run on.
+        runs-on: ubuntu-latest
+    
+        # Permissions for the GITHUB_TOKEN to allow the action to modify issues and PRs.
+        permissions:
+          issues: write
+          pull-requests: write
+    
+        steps:
+          - uses: actions/stale@v9
+            with:
+              # The token for the repository. Required.
+              repo-token: ${{ secrets.GITHUB_TOKEN }}
+    
+              # The message to post on stale issues.
+              stale-issue-message: >
+                This issue has been automatically marked as stale because it has not had
+                recent activity. It will be closed if no further activity occurs.
+                Thank you for your contributions.
+    
+              # The message to post on stale PRs.
+              stale-pr-message: >
+                This pull request has been automatically marked as stale because it has not had
+                recent activity. It will be closed if no further activity occurs.
+                Thank you for your contributions.
+    
+              # The label to apply to stale issues and PRs.
+              stale-issue-label: 'stale'
+              stale-pr-label: 'stale'
+    
+              # The number of days of inactivity before an issue or PR is marked as stale.
+              days-before-stale: 60
+    
+              # The number of days of inactivity before a stale issue or PR is closed.
+              # Set to -1 to disable closing.
+              days-before-close: 7
+    
+              # Labels that prevent an issue or PR from being marked as stale.
+              exempt-issue-labels: 'pinned,security'
+              exempt-pr-labels: 'pinned,security'
+    
+              # Exempt all issues and PRs with an assignee.
+              exempt-all-issue-assignees: true
+              exempt-all-pr-assignees: true
+    
+              # The maximum number of operations to perform per run.
+              operations-per-run: 100


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically manage stale issues and pull requests in the repository. The workflow is designed to identify issues and PRs with no recent activity, warn contributors, and eventually close them if inactivity continues.

**Automation of stale issue and PR management:**

* Added `.github/workflows/stale.yml` to schedule a daily job that marks issues and PRs as stale after 60 days of inactivity, posts a warning message, and closes them after 7 additional days if there is no further activity.
* Configured the workflow to use the `actions/stale@v9` action, with custom messages for stale issues and PRs, and applies a `stale` label.
* Set up exemptions so that issues and PRs labeled `pinned` or `security`, or those with assignees, will not be marked as stale or closed.
* Limited the number of operations per run to 100 to avoid overloading the workflow.