### PR TITLE
Adding `mkdocs.yml` for project documentation setup

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,57 @@
+site_name: Project CodeGuard
+site_description: Project CodeGuard is an AI model-agnostic security framework and ruleset that embeds secure-by-default practices into AI coding workflows (generation and review). It ships core security rules, translators for popular coding agents, and validators to test rule compliance.
+site_author: Cisco AI-enabled Security Engineering, Security and Trust
+site_url: https://cisco-sto.github.io/a2rd-project-agent-codeguard-docs
+
+theme:
+  name: material
+  # logo: assets/placeholder_codeguard.png
+  # favicon: assets/placeholder_codeguard.png
+  font:
+    text: Inter
+    code: JetBrains Mono
+  palette:
+    # Palette toggle for light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: blue
+      accent: cyan
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    # Palette toggle for dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: blue
+      accent: cyan
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.expand
+    - navigation.footer
+    - navigation.instant
+    - navigation.sections
+    - navigation.top
+    - search.highlight
+    - search.suggest
+    - content.code.copy
+    - content.code.select
+repo_url: https://github.com/project-codeguard/rules
+repo_name: project-codeguard/rules
+# edit_uri: ""
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - FAQ: faq.md
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - pymdownx.keys
+  - pymdownx.tabbed:
+      alternate_style: true


### PR DESCRIPTION
This pull request introduces a new documentation configuration for the project, setting up the foundational structure and appearance for the documentation site using MkDocs and the Material theme.

Documentation site setup:

* Added a new `mkdocs.yml` configuration file specifying the site name, description, author, and URL to establish the documentation identity and metadata.
* Configured the Material theme with custom fonts, color palettes for light and dark modes, and enabled several navigation and content features to enhance user experience.
* Set up navigation structure with links to Home, Getting Started, and FAQ pages for easier access to key documentation sections.
* Integrated useful markdown extensions for improved formatting and interactive content, such as admonitions, emoji support, and tabbed content.
* Linked the documentation to the project's GitHub repository for easy reference and potential editing.