### PR TITLE
Update mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: Project CodeGuard
 site_description: Project CodeGuard is an AI model-agnostic security framework and ruleset that embeds secure-by-default practices into AI coding workflows (generation and review). It ships core security rules, translators for popular coding agents, and validators to test rule compliance.
 site_author: Cisco AI-enabled Security Engineering, Security and Trust
-site_url: https://cisco-sto.github.io/a2rd-project-agent-codeguard-docs
+site_url: https://project-codeguard.org
 
 theme:
   name: material


### PR DESCRIPTION
This pull request updates the documentation configuration to reflect the new official website for Project CodeGuard.

Documentation update:

* Changed the `site_url` in `mkdocs.yml` from the previous GitHub Pages address to the new domain `https://project-codeguard.org`.