### PR TITLE
Add HTML and SQL language support to security rules

### DIFF
--- a/additional_rules/owasp/codeguard-0-ajax-security.md
+++ b/additional_rules/owasp/codeguard-0-ajax-security.md
@@ -2,6 +2,7 @@
 description: AJAX Security Best Practices for Client-Side Scripts
 languages:
 - c
+- html
 - javascript
 - php
 - typescript

--- a/additional_rules/owasp/codeguard-0-clickjacking-defense.md
+++ b/additional_rules/owasp/codeguard-0-clickjacking-defense.md
@@ -2,6 +2,7 @@
 description: Clickjacking Defense Best Practices
 languages:
 - c
+- html
 - javascript
 - php
 - typescript

--- a/additional_rules/owasp/codeguard-0-content-security-policy.md
+++ b/additional_rules/owasp/codeguard-0-content-security-policy.md
@@ -2,6 +2,7 @@
 description: Content Security Policy (CSP) Best Practices
 languages:
 - c
+- html
 - javascript
 - php
 - typescript

--- a/additional_rules/owasp/codeguard-0-cross-site-request-forgery-prevention.md
+++ b/additional_rules/owasp/codeguard-0-cross-site-request-forgery-prevention.md
@@ -3,6 +3,7 @@ description: Cross-Site Request Forgery (CSRF) Prevention Best Practices
 languages:
 - c
 - go
+- html
 - java
 - javascript
 - php

--- a/additional_rules/owasp/codeguard-0-cross-site-scripting-prevention.md
+++ b/additional_rules/owasp/codeguard-0-cross-site-scripting-prevention.md
@@ -2,6 +2,7 @@
 description: Cross Site Scripting (XSS) Prevention Best Practices
 languages:
 - c
+- html
 - javascript
 - php
 - typescript

--- a/additional_rules/owasp/codeguard-0-database-security.md
+++ b/additional_rules/owasp/codeguard-0-database-security.md
@@ -5,6 +5,7 @@ languages:
 - java
 - javascript
 - python
+- sql
 - yaml
 alwaysApply: false
 version: 0.1.0

--- a/additional_rules/owasp/codeguard-0-dom-based-xss-prevention.md
+++ b/additional_rules/owasp/codeguard-0-dom-based-xss-prevention.md
@@ -2,6 +2,7 @@
 description: DOM-based XSS Prevention Best Practices
 languages:
 - c
+- html
 - javascript
 - php
 - typescript

--- a/additional_rules/owasp/codeguard-0-dom-clobbering-prevention.md
+++ b/additional_rules/owasp/codeguard-0-dom-clobbering-prevention.md
@@ -2,6 +2,7 @@
 description: DOM Clobbering Prevention Best Practices
 languages:
 - c
+- html
 - javascript
 - php
 - typescript

--- a/additional_rules/owasp/codeguard-0-html5-security.md
+++ b/additional_rules/owasp/codeguard-0-html5-security.md
@@ -3,6 +3,7 @@ description: HTML5 Security Best Practices
 languages:
 - c
 - go
+- html
 - java
 - javascript
 - php

--- a/additional_rules/owasp/codeguard-0-injection-prevention.md
+++ b/additional_rules/owasp/codeguard-0-injection-prevention.md
@@ -10,6 +10,7 @@ languages:
 - python
 - ruby
 - shell
+- sql
 - typescript
 alwaysApply: false
 version: 0.1.0

--- a/additional_rules/owasp/codeguard-0-input-validation.md
+++ b/additional_rules/owasp/codeguard-0-input-validation.md
@@ -8,6 +8,7 @@ languages:
 - php
 - python
 - ruby
+- sql
 - typescript
 - xml
 alwaysApply: false

--- a/additional_rules/owasp/codeguard-0-query-parameterization.md
+++ b/additional_rules/owasp/codeguard-0-query-parameterization.md
@@ -7,6 +7,7 @@ languages:
 - php
 - ruby
 - rust
+- sql
 alwaysApply: false
 version: 0.1.0
 severity: medium

--- a/additional_rules/owasp/codeguard-0-sql-injection-prevention.md
+++ b/additional_rules/owasp/codeguard-0-sql-injection-prevention.md
@@ -9,6 +9,7 @@ languages:
 - php
 - python
 - ruby
+- sql
 - typescript
 alwaysApply: false
 version: 0.1.0

--- a/rules/codeguard-0-client-side-web-security.md
+++ b/rules/codeguard-0-client-side-web-security.md
@@ -3,6 +3,7 @@ description: Client-side web security (XSS/DOM XSS, CSP, CSRF, clickjacking, XS-
   third-party JS)
 languages:
 - c
+- html
 - javascript
 - php
 - typescript

--- a/rules/codeguard-0-data-storage.md
+++ b/rules/codeguard-0-data-storage.md
@@ -4,6 +4,7 @@ description: Data & storage security (DB isolation, TLS, least privilege, RLS/CL
 languages:
 - c
 - javascript
+- sql
 - yaml
 alwaysApply: false
 ---

--- a/rules/codeguard-0-input-validation-injection.md
+++ b/rules/codeguard-0-input-validation-injection.md
@@ -4,6 +4,7 @@ description: Input validation and injection defense (SQL/LDAP/OS), parameterizat
 languages:
 - c
 - go
+- html
 - java
 - javascript
 - php
@@ -11,6 +12,7 @@ languages:
 - python
 - ruby
 - shell
+- sql
 - typescript
 alwaysApply: false
 ---

--- a/rules/codeguard-0-session-management-and-cookies.md
+++ b/rules/codeguard-0-session-management-and-cookies.md
@@ -4,6 +4,7 @@ description: Session management and secure cookies (rotation, fixation, timeouts
 languages:
 - c
 - go
+- html
 - java
 - javascript
 - php

--- a/src/language_mappings.py
+++ b/src/language_mappings.py
@@ -64,6 +64,8 @@ LANGUAGE_TO_EXTENSIONS = {
     "glsl": [".glsl", ".vert", ".frag"],
     "hlsl": [".hlsl"],
     "wgsl": [".wgsl"],
+    "html": [".html", ".htm"],
+    "sql": [".sql", ".ddl", ".dml"],
 }
 
 # Reverse mapping: extension to language (for conversion from globs)

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 
 [[package]]
@@ -97,23 +97,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/46/61/de6cd827efad202d7057d93e0fed9294b96952e188f7384832791c7b2254/click-8.3.0.tar.gz", hash = "sha256:e7b8232224eba16f4ebe410c25ced9f7875cb5f3263ffc93cc3e8da705e229c4", size = 276943, upload-time = "2025-09-18T17:32:23.696Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/d3/9dcc0f5797f070ec8edf30fbadfb200e71d9db6b84d211e3b2085a7589a0/click-8.3.0-py3-none-any.whl", hash = "sha256:9b9f285302c6e3064f4330c05f05b81945b2a39544279343e6e7c5f27a9baddc", size = 107295, upload-time = "2025-09-18T17:32:22.42Z" },
-]
-
-[[package]]
-name = "codeguard"
-version = "0.1.0"
-source = { virtual = "." }
-dependencies = [
-    { name = "mkdocs" },
-    { name = "mkdocs-material" },
-    { name = "pyyaml" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "mkdocs", specifier = "~=1.6.1" },
-    { name = "mkdocs-material", specifier = "~=9.6.21" },
-    { name = "pyyaml", specifier = ">=6.0.2" },
 ]
 
 [[package]]
@@ -353,6 +336,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/61/33/9611380c2bdb1225fdef633e2a9610622310fed35ab11dac9620972ee088/platformdirs-4.5.0.tar.gz", hash = "sha256:70ddccdd7c99fc5942e9fc25636a8b34d04c24b335100223152c2803e4063312", size = 21632, upload-time = "2025-10-08T17:44:48.791Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/73/cb/ac7874b3e5d58441674fb70742e6c374b28b0c7cb988d37d991cde47166c/platformdirs-4.5.0-py3-none-any.whl", hash = "sha256:e578a81bb873cbb89a41fcc904c7ef523cc18284b7e3b3ccf06aca1403b7ebd3", size = 18651, upload-time = "2025-10-08T17:44:47.223Z" },
+]
+
+[[package]]
+name = "project-codeguard"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "mkdocs" },
+    { name = "mkdocs-material" },
+    { name = "pyyaml" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "mkdocs", specifier = "~=1.6.1" },
+    { name = "mkdocs-material", specifier = "~=9.6.21" },
+    { name = "pyyaml", specifier = "~=6.0.2" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request expands language support for security rule files and updates the language mappings to include `html` and `sql` where appropriate. The main changes are the addition of `html` and `sql` to the relevant security rules and the update of the language extension mapping in `src/language_mappings.py`.

Fixes #17 