### PR TITLE
Update copyright notice with hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,4 +59,4 @@ Get started in minutes:
 - **💬 Discussions**: [Join the conversation](https://github.com/project-codeguard/rules/discussions)
 - **🤝 Contributing**: [Learn how to contribute](https://github.com/project-codeguard/rules/blob/main/CONTRIBUTING.md)
 
-Copyright © 2025 Cisco Systems, Inc. Licensed under the Creative Commons Attribution 4.0 International (CC BY 4.0): https://creativecommons.org/licenses/by/4.0/
+Copyright © 2025 Cisco Systems, Inc. Licensed under the [Creative Commons Attribution 4.0 International (CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/)


### PR DESCRIPTION
This pull request makes a small documentation update to the copyright notice in the `README.md` file, improving clarity by converting the license URL into a clickable link.