### PR TITLE
added ability to bypass branch protection in actions

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -18,10 +18,18 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.CODEGUARD_APP_ID }}
+          private-key: ${{ secrets.CODEGUARD_APP_PRIVATE_KEY }}
+      
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
@@ -42,5 +50,7 @@ jobs:
           git config --local user.name "github-actions[bot]"
 
       - name: Deploy to GitHub Pages
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: uv run mkdocs gh-deploy --force --clean --verbose
 

--- a/.github/workflows/generate-ide-rules.yml
+++ b/.github/workflows/generate-ide-rules.yml
@@ -16,12 +16,21 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     
     steps:
+      - name: Generate GitHub App Token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.CODEGUARD_APP_ID }}
+          private-key: ${{ secrets.CODEGUARD_APP_PRIVATE_KEY }}
+      
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4
@@ -50,6 +59,8 @@ jobs:
 
       - name: Commit and push generated rules
         if: steps.check_changes.outputs.changes == 'true'
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"


### PR DESCRIPTION
This PR allows Github actions to bypass branch protections and generate ide_rules on merge to main and also while deploying doc site to gh-pages branch.