### PR TITLE
Tweaks to Copilot Templates

### DIFF
--- a/ide_rules/.cursor/rules/codeguard-0-api-web-services.mdc
+++ b/ide_rules/.cursor/rules/codeguard-0-api-web-services.mdc
@@ -1,6 +1,5 @@
 ---
-description: API & Web services security (REST/GraphQL/SOAP), schema validation, authn/z,
-  SSRF
+description: API & Web services security (REST/GraphQL/SOAP), schema validation, authn/z, SSRF
 globs: **/*.c,**/*.go,**/*.h,**/*.java,**/*.js,**/*.jsx,**/*.mjs,**/*.php,**/*.py,**/*.pyi,**/*.pyx,**/*.rb,**/*.ts,**/*.tsx,**/*.wsdl,**/*.xml,**/*.xsd,**/*.xslt,**/*.yaml,**/*.yml
 version: 1.0.0
 ---

--- a/ide_rules/.cursor/rules/codeguard-0-authentication-mfa.mdc
+++ b/ide_rules/.cursor/rules/codeguard-0-authentication-mfa.mdc
@@ -1,6 +1,5 @@
 ---
-description: Authentication and MFA best practices (passwords, MFA, OAuth/OIDC, SAML,
-  recovery, tokens)
+description: Authentication and MFA best practices (passwords, MFA, OAuth/OIDC, SAML, recovery, tokens)
 globs: **/*.c,**/*.go,**/*.h,**/*.java,**/*.js,**/*.jsx,**/*.kt,**/*.kts,**/*.m,**/*.mjs,**/*.php,**/*.py,**/*.pyi,**/*.pyx,**/*.rb,**/*.swift,**/*.ts,**/*.tsx
 version: 1.0.0
 ---

--- a/ide_rules/.cursor/rules/codeguard-0-authorization-access-control.mdc
+++ b/ide_rules/.cursor/rules/codeguard-0-authorization-access-control.mdc
@@ -1,6 +1,5 @@
 ---
-description: Authorization and access control (RBAC/ABAC/ReBAC, IDOR, mass assignment,
-  transaction auth)
+description: Authorization and access control (RBAC/ABAC/ReBAC, IDOR, mass assignment, transaction auth)
 globs: **/*.c,**/*.go,**/*.h,**/*.java,**/*.js,**/*.jsx,**/*.mjs,**/*.php,**/*.py,**/*.pyi,**/*.pyx,**/*.rb,**/*.ts,**/*.tsx,**/*.yaml,**/*.yml
 version: 1.0.0
 ---

--- a/ide_rules/.cursor/rules/codeguard-0-client-side-web-security.mdc
+++ b/ide_rules/.cursor/rules/codeguard-0-client-side-web-security.mdc
@@ -1,6 +1,5 @@
 ---
-description: Client-side web security (XSS/DOM XSS, CSP, CSRF, clickjacking, XS-Leaks,
-  third-party JS)
+description: Client-side web security (XSS/DOM XSS, CSP, CSRF, clickjacking, XS-Leaks, third-party JS)
 globs: **/*.c,**/*.h,**/*.htm,**/*.html,**/*.js,**/*.jsx,**/*.mjs,**/*.php,**/*.ts,**/*.tsx,**/*.v
 version: 1.0.0
 ---

--- a/ide_rules/.cursor/rules/codeguard-0-cloud-orchestration-kubernetes.mdc
+++ b/ide_rules/.cursor/rules/codeguard-0-cloud-orchestration-kubernetes.mdc
@@ -1,6 +1,5 @@
 ---
-description: Kubernetes hardening (RBAC, admission policies, network policies, secrets,
-  supply chain)
+description: Kubernetes hardening (RBAC, admission policies, network policies, secrets, supply chain)
 globs: **/*.js,**/*.jsx,**/*.mjs,**/*.yaml,**/*.yml
 version: 1.0.0
 ---

--- a/ide_rules/.cursor/rules/codeguard-0-data-storage.mdc
+++ b/ide_rules/.cursor/rules/codeguard-0-data-storage.mdc
@@ -1,6 +1,5 @@
 ---
-description: Data & storage security (DB isolation, TLS, least privilege, RLS/CLS,
-  backups, auditing)
+description: Data & storage security (DB isolation, TLS, least privilege, RLS/CLS, backups, auditing)
 globs: **/*.c,**/*.ddl,**/*.dml,**/*.h,**/*.js,**/*.jsx,**/*.mjs,**/*.sql,**/*.yaml,**/*.yml
 version: 1.0.0
 ---

--- a/ide_rules/.cursor/rules/codeguard-0-devops-ci-cd-containers.mdc
+++ b/ide_rules/.cursor/rules/codeguard-0-devops-ci-cd-containers.mdc
@@ -1,6 +1,5 @@
 ---
-description: DevOps, CI/CD, and containers (pipeline hardening, artifacts, Docker/K8s
-  images, virtual patching, toolchain)
+description: DevOps, CI/CD, and containers (pipeline hardening, artifacts, Docker/K8s images, virtual patching, toolchain)
 globs: **/*.bash,**/*.dockerfile,**/*.js,**/*.jsx,**/*.mjs,**/*.ps1,**/*.sh,**/*.wsdl,**/*.xml,**/*.xsd,**/*.xslt,**/*.yaml,**/*.yml,Dockerfile*,docker-compose*
 version: 1.0.0
 ---

--- a/ide_rules/.cursor/rules/codeguard-0-file-handling-and-uploads.mdc
+++ b/ide_rules/.cursor/rules/codeguard-0-file-handling-and-uploads.mdc
@@ -1,6 +1,5 @@
 ---
-description: Secure file handling & uploads (validation, storage isolation, scanning,
-  safe delivery)
+description: Secure file handling & uploads (validation, storage isolation, scanning, safe delivery)
 globs: **/*.c,**/*.go,**/*.h,**/*.java,**/*.js,**/*.jsx,**/*.mjs,**/*.php,**/*.py,**/*.pyi,**/*.pyx,**/*.rb,**/*.ts,**/*.tsx
 version: 1.0.0
 ---

--- a/ide_rules/.cursor/rules/codeguard-0-framework-and-languages.mdc
+++ b/ide_rules/.cursor/rules/codeguard-0-framework-and-languages.mdc
@@ -1,6 +1,5 @@
 ---
-description: Framework & language security guides (Django/DRF, Laravel/Symfony/Rails,
-  .NET, Java/JAAS, Node.js, PHP config)
+description: Framework & language security guides (Django/DRF, Laravel/Symfony/Rails, .NET, Java/JAAS, Node.js, PHP config)
 globs: **/*.c,**/*.h,**/*.java,**/*.js,**/*.jsx,**/*.kt,**/*.kts,**/*.mjs,**/*.php,**/*.py,**/*.pyi,**/*.pyx,**/*.rb,**/*.ts,**/*.tsx,**/*.wsdl,**/*.xml,**/*.xsd,**/*.xslt,**/*.yaml,**/*.yml
 version: 1.0.0
 ---

--- a/ide_rules/.cursor/rules/codeguard-0-input-validation-injection.mdc
+++ b/ide_rules/.cursor/rules/codeguard-0-input-validation-injection.mdc
@@ -1,6 +1,5 @@
 ---
-description: Input validation and injection defense (SQL/LDAP/OS), parameterization,
-  prototype pollution
+description: Input validation and injection defense (SQL/LDAP/OS), parameterization, prototype pollution
 globs: **/*.bash,**/*.c,**/*.ddl,**/*.dml,**/*.go,**/*.h,**/*.htm,**/*.html,**/*.java,**/*.js,**/*.jsx,**/*.mjs,**/*.php,**/*.ps1,**/*.py,**/*.pyi,**/*.pyx,**/*.rb,**/*.sh,**/*.sql,**/*.ts,**/*.tsx
 version: 1.0.0
 ---

--- a/ide_rules/.cursor/rules/codeguard-0-logging.mdc
+++ b/ide_rules/.cursor/rules/codeguard-0-logging.mdc
@@ -1,6 +1,5 @@
 ---
-description: Logging & monitoring (structured telemetry, redaction, integrity, detection
-  & alerting)
+description: Logging & monitoring (structured telemetry, redaction, integrity, detection & alerting)
 globs: **/*.c,**/*.h,**/*.js,**/*.jsx,**/*.mjs,**/*.yaml,**/*.yml
 version: 1.0.0
 ---

--- a/ide_rules/.cursor/rules/codeguard-0-mobile-apps.mdc
+++ b/ide_rules/.cursor/rules/codeguard-0-mobile-apps.mdc
@@ -1,6 +1,5 @@
 ---
-description: 'Mobile app security (iOS/Android): storage, transport, code integrity,
-  biometrics, permissions'
+description: 'Mobile app security (iOS/Android): storage, transport, code integrity, biometrics, permissions'
 globs: **/*.java,**/*.js,**/*.jsx,**/*.kt,**/*.kts,**/*.m,**/*.mjs,**/*.pl,**/*.pm,**/*.swift,**/*.wsdl,**/*.xml,**/*.xsd,**/*.xslt
 version: 1.0.0
 ---

--- a/ide_rules/.cursor/rules/codeguard-0-privacy-data-protection.mdc
+++ b/ide_rules/.cursor/rules/codeguard-0-privacy-data-protection.mdc
@@ -1,6 +1,5 @@
 ---
-description: Privacy & data protection (minimization, classification, encryption,
-  rights, transparency)
+description: Privacy & data protection (minimization, classification, encryption, rights, transparency)
 globs: **/*.js,**/*.jsx,**/*.m,**/*.mjs,**/*.yaml,**/*.yml
 version: 1.0.0
 ---

--- a/ide_rules/.cursor/rules/codeguard-0-session-management-and-cookies.mdc
+++ b/ide_rules/.cursor/rules/codeguard-0-session-management-and-cookies.mdc
@@ -1,6 +1,5 @@
 ---
-description: Session management and secure cookies (rotation, fixation, timeouts,
-  theft detection)
+description: Session management and secure cookies (rotation, fixation, timeouts, theft detection)
 globs: **/*.c,**/*.go,**/*.h,**/*.htm,**/*.html,**/*.java,**/*.js,**/*.jsx,**/*.mjs,**/*.php,**/*.py,**/*.pyi,**/*.pyx,**/*.rb,**/*.ts,**/*.tsx
 version: 1.0.0
 ---

--- a/ide_rules/.cursor/rules/codeguard-0-supply-chain-security.mdc
+++ b/ide_rules/.cursor/rules/codeguard-0-supply-chain-security.mdc
@@ -1,6 +1,5 @@
 ---
-description: Dependency & supply chain security (pinning, SBOM, provenance, integrity,
-  private registries)
+description: Dependency & supply chain security (pinning, SBOM, provenance, integrity, private registries)
 globs: **/*.dockerfile,**/*.js,**/*.jsx,**/*.mjs,**/*.yaml,**/*.yml,Dockerfile*,docker-compose*
 version: 1.0.0
 ---

--- a/ide_rules/.cursor/rules/codeguard-0-xml-and-serialization.mdc
+++ b/ide_rules/.cursor/rules/codeguard-0-xml-and-serialization.mdc
@@ -1,6 +1,5 @@
 ---
-description: XML security and safe deserialization (DTD/XXE hardening, schema validation,
-  no unsafe native deserialization)
+description: XML security and safe deserialization (DTD/XXE hardening, schema validation, no unsafe native deserialization)
 globs: **/*.c,**/*.go,**/*.h,**/*.java,**/*.php,**/*.py,**/*.pyi,**/*.pyx,**/*.rb,**/*.wsdl,**/*.xml,**/*.xsd,**/*.xslt
 version: 1.0.0
 ---

--- a/ide_rules/.github/instructions/codeguard-0-additional-cryptography.instructions.md
+++ b/ide_rules/.github/instructions/codeguard-0-additional-cryptography.instructions.md
@@ -1,6 +1,6 @@
 ---
 applyTo: '**/*.c,**/*.go,**/*.h,**/*.java,**/*.js,**/*.jsx,**/*.kt,**/*.kts,**/*.m,**/*.mjs,**/*.php,**/*.py,**/*.pyi,**/*.pyx,**/*.rb,**/*.swift,**/*.ts,**/*.tsx,**/*.wsdl,**/*.xml,**/*.xsd,**/*.xslt,**/*.yaml,**/*.yml'
-title: Additional Cryptography guidance
+description: Additional Cryptography guidance
 version: 1.0.0
 ---
 

--- a/ide_rules/.github/instructions/codeguard-0-api-web-services.instructions.md
+++ b/ide_rules/.github/instructions/codeguard-0-api-web-services.instructions.md
@@ -1,7 +1,6 @@
 ---
 applyTo: '**/*.c,**/*.go,**/*.h,**/*.java,**/*.js,**/*.jsx,**/*.mjs,**/*.php,**/*.py,**/*.pyi,**/*.pyx,**/*.rb,**/*.ts,**/*.tsx,**/*.wsdl,**/*.xml,**/*.xsd,**/*.xslt,**/*.yaml,**/*.yml'
-title: API & Web services security (REST/GraphQL/SOAP), schema validation, authn/z,
-  SSRF
+description: API & Web services security (REST/GraphQL/SOAP), schema validation, authn/z, SSRF
 version: 1.0.0
 ---
 

--- a/ide_rules/.github/instructions/codeguard-0-authentication-mfa.instructions.md
+++ b/ide_rules/.github/instructions/codeguard-0-authentication-mfa.instructions.md
@@ -1,7 +1,6 @@
 ---
 applyTo: '**/*.c,**/*.go,**/*.h,**/*.java,**/*.js,**/*.jsx,**/*.kt,**/*.kts,**/*.m,**/*.mjs,**/*.php,**/*.py,**/*.pyi,**/*.pyx,**/*.rb,**/*.swift,**/*.ts,**/*.tsx'
-title: Authentication and MFA best practices (passwords, MFA, OAuth/OIDC, SAML, recovery,
-  tokens)
+description: Authentication and MFA best practices (passwords, MFA, OAuth/OIDC, SAML, recovery, tokens)
 version: 1.0.0
 ---
 

--- a/ide_rules/.github/instructions/codeguard-0-authorization-access-control.instructions.md
+++ b/ide_rules/.github/instructions/codeguard-0-authorization-access-control.instructions.md
@@ -1,7 +1,6 @@
 ---
 applyTo: '**/*.c,**/*.go,**/*.h,**/*.java,**/*.js,**/*.jsx,**/*.mjs,**/*.php,**/*.py,**/*.pyi,**/*.pyx,**/*.rb,**/*.ts,**/*.tsx,**/*.yaml,**/*.yml'
-title: Authorization and access control (RBAC/ABAC/ReBAC, IDOR, mass assignment, transaction
-  auth)
+description: Authorization and access control (RBAC/ABAC/ReBAC, IDOR, mass assignment, transaction auth)
 version: 1.0.0
 ---
 

--- a/ide_rules/.github/instructions/codeguard-0-client-side-web-security.instructions.md
+++ b/ide_rules/.github/instructions/codeguard-0-client-side-web-security.instructions.md
@@ -1,7 +1,6 @@
 ---
 applyTo: '**/*.c,**/*.h,**/*.htm,**/*.html,**/*.js,**/*.jsx,**/*.mjs,**/*.php,**/*.ts,**/*.tsx,**/*.v'
-title: Client-side web security (XSS/DOM XSS, CSP, CSRF, clickjacking, XS-Leaks, third-party
-  JS)
+description: Client-side web security (XSS/DOM XSS, CSP, CSRF, clickjacking, XS-Leaks, third-party JS)
 version: 1.0.0
 ---
 

--- a/ide_rules/.github/instructions/codeguard-0-cloud-orchestration-kubernetes.instructions.md
+++ b/ide_rules/.github/instructions/codeguard-0-cloud-orchestration-kubernetes.instructions.md
@@ -1,7 +1,6 @@
 ---
 applyTo: '**/*.js,**/*.jsx,**/*.mjs,**/*.yaml,**/*.yml'
-title: Kubernetes hardening (RBAC, admission policies, network policies, secrets,
-  supply chain)
+description: Kubernetes hardening (RBAC, admission policies, network policies, secrets, supply chain)
 version: 1.0.0
 ---
 

--- a/ide_rules/.github/instructions/codeguard-0-data-storage.instructions.md
+++ b/ide_rules/.github/instructions/codeguard-0-data-storage.instructions.md
@@ -1,7 +1,6 @@
 ---
 applyTo: '**/*.c,**/*.ddl,**/*.dml,**/*.h,**/*.js,**/*.jsx,**/*.mjs,**/*.sql,**/*.yaml,**/*.yml'
-title: Data & storage security (DB isolation, TLS, least privilege, RLS/CLS, backups,
-  auditing)
+description: Data & storage security (DB isolation, TLS, least privilege, RLS/CLS, backups, auditing)
 version: 1.0.0
 ---
 

--- a/ide_rules/.github/instructions/codeguard-0-devops-ci-cd-containers.instructions.md
+++ b/ide_rules/.github/instructions/codeguard-0-devops-ci-cd-containers.instructions.md
@@ -1,7 +1,6 @@
 ---
 applyTo: '**/*.bash,**/*.dockerfile,**/*.js,**/*.jsx,**/*.mjs,**/*.ps1,**/*.sh,**/*.wsdl,**/*.xml,**/*.xsd,**/*.xslt,**/*.yaml,**/*.yml,Dockerfile*,docker-compose*'
-title: DevOps, CI/CD, and containers (pipeline hardening, artifacts, Docker/K8s images,
-  virtual patching, toolchain)
+description: DevOps, CI/CD, and containers (pipeline hardening, artifacts, Docker/K8s images, virtual patching, toolchain)
 version: 1.0.0
 ---
 

--- a/ide_rules/.github/instructions/codeguard-0-file-handling-and-uploads.instructions.md
+++ b/ide_rules/.github/instructions/codeguard-0-file-handling-and-uploads.instructions.md
@@ -1,7 +1,6 @@
 ---
 applyTo: '**/*.c,**/*.go,**/*.h,**/*.java,**/*.js,**/*.jsx,**/*.mjs,**/*.php,**/*.py,**/*.pyi,**/*.pyx,**/*.rb,**/*.ts,**/*.tsx'
-title: Secure file handling & uploads (validation, storage isolation, scanning, safe
-  delivery)
+description: Secure file handling & uploads (validation, storage isolation, scanning, safe delivery)
 version: 1.0.0
 ---
 

--- a/ide_rules/.github/instructions/codeguard-0-framework-and-languages.instructions.md
+++ b/ide_rules/.github/instructions/codeguard-0-framework-and-languages.instructions.md
@@ -1,7 +1,6 @@
 ---
 applyTo: '**/*.c,**/*.h,**/*.java,**/*.js,**/*.jsx,**/*.kt,**/*.kts,**/*.mjs,**/*.php,**/*.py,**/*.pyi,**/*.pyx,**/*.rb,**/*.ts,**/*.tsx,**/*.wsdl,**/*.xml,**/*.xsd,**/*.xslt,**/*.yaml,**/*.yml'
-title: Framework & language security guides (Django/DRF, Laravel/Symfony/Rails, .NET,
-  Java/JAAS, Node.js, PHP config)
+description: Framework & language security guides (Django/DRF, Laravel/Symfony/Rails, .NET, Java/JAAS, Node.js, PHP config)
 version: 1.0.0
 ---
 

--- a/ide_rules/.github/instructions/codeguard-0-iac-security.instructions.md
+++ b/ide_rules/.github/instructions/codeguard-0-iac-security.instructions.md
@@ -1,6 +1,6 @@
 ---
 applyTo: '**/*.bash,**/*.c,**/*.d,**/*.h,**/*.js,**/*.jsx,**/*.mjs,**/*.ps1,**/*.rb,**/*.sh,**/*.yaml,**/*.yml'
-title: Infrastructure as Code Security
+description: Infrastructure as Code Security
 version: 1.0.0
 ---
 

--- a/ide_rules/.github/instructions/codeguard-0-input-validation-injection.instructions.md
+++ b/ide_rules/.github/instructions/codeguard-0-input-validation-injection.instructions.md
@@ -1,7 +1,6 @@
 ---
 applyTo: '**/*.bash,**/*.c,**/*.ddl,**/*.dml,**/*.go,**/*.h,**/*.htm,**/*.html,**/*.java,**/*.js,**/*.jsx,**/*.mjs,**/*.php,**/*.ps1,**/*.py,**/*.pyi,**/*.pyx,**/*.rb,**/*.sh,**/*.sql,**/*.ts,**/*.tsx'
-title: Input validation and injection defense (SQL/LDAP/OS), parameterization, prototype
-  pollution
+description: Input validation and injection defense (SQL/LDAP/OS), parameterization, prototype pollution
 version: 1.0.0
 ---
 

--- a/ide_rules/.github/instructions/codeguard-0-logging.instructions.md
+++ b/ide_rules/.github/instructions/codeguard-0-logging.instructions.md
@@ -1,7 +1,6 @@
 ---
 applyTo: '**/*.c,**/*.h,**/*.js,**/*.jsx,**/*.mjs,**/*.yaml,**/*.yml'
-title: Logging & monitoring (structured telemetry, redaction, integrity, detection
-  & alerting)
+description: Logging & monitoring (structured telemetry, redaction, integrity, detection & alerting)
 version: 1.0.0
 ---
 

--- a/ide_rules/.github/instructions/codeguard-0-mobile-apps.instructions.md
+++ b/ide_rules/.github/instructions/codeguard-0-mobile-apps.instructions.md
@@ -1,7 +1,6 @@
 ---
 applyTo: '**/*.java,**/*.js,**/*.jsx,**/*.kt,**/*.kts,**/*.m,**/*.mjs,**/*.pl,**/*.pm,**/*.swift,**/*.wsdl,**/*.xml,**/*.xsd,**/*.xslt'
-title: 'Mobile app security (iOS/Android): storage, transport, code integrity, biometrics,
-  permissions'
+description: 'Mobile app security (iOS/Android): storage, transport, code integrity, biometrics, permissions'
 version: 1.0.0
 ---
 

--- a/ide_rules/.github/instructions/codeguard-0-privacy-data-protection.instructions.md
+++ b/ide_rules/.github/instructions/codeguard-0-privacy-data-protection.instructions.md
@@ -1,7 +1,6 @@
 ---
 applyTo: '**/*.js,**/*.jsx,**/*.m,**/*.mjs,**/*.yaml,**/*.yml'
-title: Privacy & data protection (minimization, classification, encryption, rights,
-  transparency)
+description: Privacy & data protection (minimization, classification, encryption, rights, transparency)
 version: 1.0.0
 ---
 

--- a/ide_rules/.github/instructions/codeguard-0-session-management-and-cookies.instructions.md
+++ b/ide_rules/.github/instructions/codeguard-0-session-management-and-cookies.instructions.md
@@ -1,7 +1,6 @@
 ---
 applyTo: '**/*.c,**/*.go,**/*.h,**/*.htm,**/*.html,**/*.java,**/*.js,**/*.jsx,**/*.mjs,**/*.php,**/*.py,**/*.pyi,**/*.pyx,**/*.rb,**/*.ts,**/*.tsx'
-title: Session management and secure cookies (rotation, fixation, timeouts, theft
-  detection)
+description: Session management and secure cookies (rotation, fixation, timeouts, theft detection)
 version: 1.0.0
 ---
 

--- a/ide_rules/.github/instructions/codeguard-0-supply-chain-security.instructions.md
+++ b/ide_rules/.github/instructions/codeguard-0-supply-chain-security.instructions.md
@@ -1,7 +1,6 @@
 ---
 applyTo: '**/*.dockerfile,**/*.js,**/*.jsx,**/*.mjs,**/*.yaml,**/*.yml,Dockerfile*,docker-compose*'
-title: Dependency & supply chain security (pinning, SBOM, provenance, integrity, private
-  registries)
+description: Dependency & supply chain security (pinning, SBOM, provenance, integrity, private registries)
 version: 1.0.0
 ---
 

--- a/ide_rules/.github/instructions/codeguard-0-xml-and-serialization.instructions.md
+++ b/ide_rules/.github/instructions/codeguard-0-xml-and-serialization.instructions.md
@@ -1,7 +1,6 @@
 ---
 applyTo: '**/*.c,**/*.go,**/*.h,**/*.java,**/*.php,**/*.py,**/*.pyi,**/*.pyx,**/*.rb,**/*.wsdl,**/*.xml,**/*.xsd,**/*.xslt'
-title: XML security and safe deserialization (DTD/XXE hardening, schema validation,
-  no unsafe native deserialization)
+description: XML security and safe deserialization (DTD/XXE hardening, schema validation, no unsafe native deserialization)
 version: 1.0.0
 ---
 

--- a/ide_rules/.github/instructions/codeguard-1-crypto-algorithms.instructions.md
+++ b/ide_rules/.github/instructions/codeguard-1-crypto-algorithms.instructions.md
@@ -1,6 +1,6 @@
 ---
 applyTo: '**/*'
-title: Cryptographic Security Guidelines
+description: Cryptographic Security Guidelines
 version: 1.0.0
 ---
 

--- a/ide_rules/.github/instructions/codeguard-1-digital-certificates.instructions.md
+++ b/ide_rules/.github/instructions/codeguard-1-digital-certificates.instructions.md
@@ -1,6 +1,6 @@
 ---
 applyTo: '**/*'
-title: Certificate Best Practices
+description: Certificate Best Practices
 version: 1.0.0
 ---
 

--- a/ide_rules/.github/instructions/codeguard-1-hardcoded-credentials.instructions.md
+++ b/ide_rules/.github/instructions/codeguard-1-hardcoded-credentials.instructions.md
@@ -1,6 +1,6 @@
 ---
 applyTo: '**/*'
-title: No Hardcoded Credentials
+description: No Hardcoded Credentials
 version: 1.0.0
 ---
 

--- a/ide_rules/.github/instructions/codeguard-1-safe-c-functions.instructions.md
+++ b/ide_rules/.github/instructions/codeguard-1-safe-c-functions.instructions.md
@@ -1,6 +1,6 @@
 ---
 applyTo: '**/*'
-title: Safe C Functions and Memory and String Safety Guidelines
+description: Safe C Functions and Memory and String Safety Guidelines
 version: 1.0.0
 ---
 

--- a/ide_rules/.windsurf/rules/codeguard-0-api-web-services.md
+++ b/ide_rules/.windsurf/rules/codeguard-0-api-web-services.md
@@ -1,8 +1,7 @@
 ---
 trigger: glob
 globs: **/*.c,**/*.go,**/*.h,**/*.java,**/*.js,**/*.jsx,**/*.mjs,**/*.php,**/*.py,**/*.pyi,**/*.pyx,**/*.rb,**/*.ts,**/*.tsx,**/*.wsdl,**/*.xml,**/*.xsd,**/*.xslt,**/*.yaml,**/*.yml
-title: API & Web services security (REST/GraphQL/SOAP), schema validation, authn/z,
-  SSRF
+title: API & Web services security (REST/GraphQL/SOAP), schema validation, authn/z, SSRF
 version: 1.0.0
 ---
 

--- a/ide_rules/.windsurf/rules/codeguard-0-authentication-mfa.md
+++ b/ide_rules/.windsurf/rules/codeguard-0-authentication-mfa.md
@@ -1,8 +1,7 @@
 ---
 trigger: glob
 globs: **/*.c,**/*.go,**/*.h,**/*.java,**/*.js,**/*.jsx,**/*.kt,**/*.kts,**/*.m,**/*.mjs,**/*.php,**/*.py,**/*.pyi,**/*.pyx,**/*.rb,**/*.swift,**/*.ts,**/*.tsx
-title: Authentication and MFA best practices (passwords, MFA, OAuth/OIDC, SAML, recovery,
-  tokens)
+title: Authentication and MFA best practices (passwords, MFA, OAuth/OIDC, SAML, recovery, tokens)
 version: 1.0.0
 ---
 

--- a/ide_rules/.windsurf/rules/codeguard-0-authorization-access-control.md
+++ b/ide_rules/.windsurf/rules/codeguard-0-authorization-access-control.md
@@ -1,8 +1,7 @@
 ---
 trigger: glob
 globs: **/*.c,**/*.go,**/*.h,**/*.java,**/*.js,**/*.jsx,**/*.mjs,**/*.php,**/*.py,**/*.pyi,**/*.pyx,**/*.rb,**/*.ts,**/*.tsx,**/*.yaml,**/*.yml
-title: Authorization and access control (RBAC/ABAC/ReBAC, IDOR, mass assignment, transaction
-  auth)
+title: Authorization and access control (RBAC/ABAC/ReBAC, IDOR, mass assignment, transaction auth)
 version: 1.0.0
 ---
 

--- a/ide_rules/.windsurf/rules/codeguard-0-client-side-web-security.md
+++ b/ide_rules/.windsurf/rules/codeguard-0-client-side-web-security.md
@@ -1,8 +1,7 @@
 ---
 trigger: glob
 globs: **/*.c,**/*.h,**/*.htm,**/*.html,**/*.js,**/*.jsx,**/*.mjs,**/*.php,**/*.ts,**/*.tsx,**/*.v
-title: Client-side web security (XSS/DOM XSS, CSP, CSRF, clickjacking, XS-Leaks, third-party
-  JS)
+title: Client-side web security (XSS/DOM XSS, CSP, CSRF, clickjacking, XS-Leaks, third-party JS)
 version: 1.0.0
 ---
 

--- a/ide_rules/.windsurf/rules/codeguard-0-cloud-orchestration-kubernetes.md
+++ b/ide_rules/.windsurf/rules/codeguard-0-cloud-orchestration-kubernetes.md
@@ -1,8 +1,7 @@
 ---
 trigger: glob
 globs: **/*.js,**/*.jsx,**/*.mjs,**/*.yaml,**/*.yml
-title: Kubernetes hardening (RBAC, admission policies, network policies, secrets,
-  supply chain)
+title: Kubernetes hardening (RBAC, admission policies, network policies, secrets, supply chain)
 version: 1.0.0
 ---
 

--- a/ide_rules/.windsurf/rules/codeguard-0-data-storage.md
+++ b/ide_rules/.windsurf/rules/codeguard-0-data-storage.md
@@ -1,8 +1,7 @@
 ---
 trigger: glob
 globs: **/*.c,**/*.ddl,**/*.dml,**/*.h,**/*.js,**/*.jsx,**/*.mjs,**/*.sql,**/*.yaml,**/*.yml
-title: Data & storage security (DB isolation, TLS, least privilege, RLS/CLS, backups,
-  auditing)
+title: Data & storage security (DB isolation, TLS, least privilege, RLS/CLS, backups, auditing)
 version: 1.0.0
 ---
 

--- a/ide_rules/.windsurf/rules/codeguard-0-devops-ci-cd-containers.md
+++ b/ide_rules/.windsurf/rules/codeguard-0-devops-ci-cd-containers.md
@@ -1,8 +1,7 @@
 ---
 trigger: glob
 globs: **/*.bash,**/*.dockerfile,**/*.js,**/*.jsx,**/*.mjs,**/*.ps1,**/*.sh,**/*.wsdl,**/*.xml,**/*.xsd,**/*.xslt,**/*.yaml,**/*.yml,Dockerfile*,docker-compose*
-title: DevOps, CI/CD, and containers (pipeline hardening, artifacts, Docker/K8s images,
-  virtual patching, toolchain)
+title: DevOps, CI/CD, and containers (pipeline hardening, artifacts, Docker/K8s images, virtual patching, toolchain)
 version: 1.0.0
 ---
 

--- a/ide_rules/.windsurf/rules/codeguard-0-file-handling-and-uploads.md
+++ b/ide_rules/.windsurf/rules/codeguard-0-file-handling-and-uploads.md
@@ -1,8 +1,7 @@
 ---
 trigger: glob
 globs: **/*.c,**/*.go,**/*.h,**/*.java,**/*.js,**/*.jsx,**/*.mjs,**/*.php,**/*.py,**/*.pyi,**/*.pyx,**/*.rb,**/*.ts,**/*.tsx
-title: Secure file handling & uploads (validation, storage isolation, scanning, safe
-  delivery)
+title: Secure file handling & uploads (validation, storage isolation, scanning, safe delivery)
 version: 1.0.0
 ---
 

--- a/ide_rules/.windsurf/rules/codeguard-0-framework-and-languages.md
+++ b/ide_rules/.windsurf/rules/codeguard-0-framework-and-languages.md
@@ -1,8 +1,7 @@
 ---
 trigger: glob
 globs: **/*.c,**/*.h,**/*.java,**/*.js,**/*.jsx,**/*.kt,**/*.kts,**/*.mjs,**/*.php,**/*.py,**/*.pyi,**/*.pyx,**/*.rb,**/*.ts,**/*.tsx,**/*.wsdl,**/*.xml,**/*.xsd,**/*.xslt,**/*.yaml,**/*.yml
-title: Framework & language security guides (Django/DRF, Laravel/Symfony/Rails, .NET,
-  Java/JAAS, Node.js, PHP config)
+title: Framework & language security guides (Django/DRF, Laravel/Symfony/Rails, .NET, Java/JAAS, Node.js, PHP config)
 version: 1.0.0
 ---
 

--- a/ide_rules/.windsurf/rules/codeguard-0-input-validation-injection.md
+++ b/ide_rules/.windsurf/rules/codeguard-0-input-validation-injection.md
@@ -1,8 +1,7 @@
 ---
 trigger: glob
 globs: **/*.bash,**/*.c,**/*.ddl,**/*.dml,**/*.go,**/*.h,**/*.htm,**/*.html,**/*.java,**/*.js,**/*.jsx,**/*.mjs,**/*.php,**/*.ps1,**/*.py,**/*.pyi,**/*.pyx,**/*.rb,**/*.sh,**/*.sql,**/*.ts,**/*.tsx
-title: Input validation and injection defense (SQL/LDAP/OS), parameterization, prototype
-  pollution
+title: Input validation and injection defense (SQL/LDAP/OS), parameterization, prototype pollution
 version: 1.0.0
 ---
 

--- a/ide_rules/.windsurf/rules/codeguard-0-logging.md
+++ b/ide_rules/.windsurf/rules/codeguard-0-logging.md
@@ -1,8 +1,7 @@
 ---
 trigger: glob
 globs: **/*.c,**/*.h,**/*.js,**/*.jsx,**/*.mjs,**/*.yaml,**/*.yml
-title: Logging & monitoring (structured telemetry, redaction, integrity, detection
-  & alerting)
+title: Logging & monitoring (structured telemetry, redaction, integrity, detection & alerting)
 version: 1.0.0
 ---
 

--- a/ide_rules/.windsurf/rules/codeguard-0-mobile-apps.md
+++ b/ide_rules/.windsurf/rules/codeguard-0-mobile-apps.md
@@ -1,8 +1,7 @@
 ---
 trigger: glob
 globs: **/*.java,**/*.js,**/*.jsx,**/*.kt,**/*.kts,**/*.m,**/*.mjs,**/*.pl,**/*.pm,**/*.swift,**/*.wsdl,**/*.xml,**/*.xsd,**/*.xslt
-title: 'Mobile app security (iOS/Android): storage, transport, code integrity, biometrics,
-  permissions'
+title: 'Mobile app security (iOS/Android): storage, transport, code integrity, biometrics, permissions'
 version: 1.0.0
 ---
 

--- a/ide_rules/.windsurf/rules/codeguard-0-privacy-data-protection.md
+++ b/ide_rules/.windsurf/rules/codeguard-0-privacy-data-protection.md
@@ -1,8 +1,7 @@
 ---
 trigger: glob
 globs: **/*.js,**/*.jsx,**/*.m,**/*.mjs,**/*.yaml,**/*.yml
-title: Privacy & data protection (minimization, classification, encryption, rights,
-  transparency)
+title: Privacy & data protection (minimization, classification, encryption, rights, transparency)
 version: 1.0.0
 ---
 

--- a/ide_rules/.windsurf/rules/codeguard-0-session-management-and-cookies.md
+++ b/ide_rules/.windsurf/rules/codeguard-0-session-management-and-cookies.md
@@ -1,8 +1,7 @@
 ---
 trigger: glob
 globs: **/*.c,**/*.go,**/*.h,**/*.htm,**/*.html,**/*.java,**/*.js,**/*.jsx,**/*.mjs,**/*.php,**/*.py,**/*.pyi,**/*.pyx,**/*.rb,**/*.ts,**/*.tsx
-title: Session management and secure cookies (rotation, fixation, timeouts, theft
-  detection)
+title: Session management and secure cookies (rotation, fixation, timeouts, theft detection)
 version: 1.0.0
 ---
 

--- a/ide_rules/.windsurf/rules/codeguard-0-supply-chain-security.md
+++ b/ide_rules/.windsurf/rules/codeguard-0-supply-chain-security.md
@@ -1,8 +1,7 @@
 ---
 trigger: glob
 globs: **/*.dockerfile,**/*.js,**/*.jsx,**/*.mjs,**/*.yaml,**/*.yml,Dockerfile*,docker-compose*
-title: Dependency & supply chain security (pinning, SBOM, provenance, integrity, private
-  registries)
+title: Dependency & supply chain security (pinning, SBOM, provenance, integrity, private registries)
 version: 1.0.0
 ---
 

--- a/ide_rules/.windsurf/rules/codeguard-0-xml-and-serialization.md
+++ b/ide_rules/.windsurf/rules/codeguard-0-xml-and-serialization.md
@@ -1,8 +1,7 @@
 ---
 trigger: glob
 globs: **/*.c,**/*.go,**/*.h,**/*.java,**/*.php,**/*.py,**/*.pyi,**/*.pyx,**/*.rb,**/*.wsdl,**/*.xml,**/*.xsd,**/*.xslt
-title: XML security and safe deserialization (DTD/XXE hardening, schema validation,
-  no unsafe native deserialization)
+title: XML security and safe deserialization (DTD/XXE hardening, schema validation, no unsafe native deserialization)
 version: 1.0.0
 ---
 

--- a/skills/software-security/rules/codeguard-0-api-web-services.md
+++ b/skills/software-security/rules/codeguard-0-api-web-services.md
@@ -1,6 +1,5 @@
 ---
-description: API & Web services security (REST/GraphQL/SOAP), schema validation, authn/z,
-  SSRF
+description: API & Web services security (REST/GraphQL/SOAP), schema validation, authn/z, SSRF
 languages:
 - c
 - go

--- a/skills/software-security/rules/codeguard-0-authentication-mfa.md
+++ b/skills/software-security/rules/codeguard-0-authentication-mfa.md
@@ -1,6 +1,5 @@
 ---
-description: Authentication and MFA best practices (passwords, MFA, OAuth/OIDC, SAML,
-  recovery, tokens)
+description: Authentication and MFA best practices (passwords, MFA, OAuth/OIDC, SAML, recovery, tokens)
 languages:
 - c
 - go

--- a/skills/software-security/rules/codeguard-0-authorization-access-control.md
+++ b/skills/software-security/rules/codeguard-0-authorization-access-control.md
@@ -1,6 +1,5 @@
 ---
-description: Authorization and access control (RBAC/ABAC/ReBAC, IDOR, mass assignment,
-  transaction auth)
+description: Authorization and access control (RBAC/ABAC/ReBAC, IDOR, mass assignment, transaction auth)
 languages:
 - c
 - go

--- a/skills/software-security/rules/codeguard-0-client-side-web-security.md
+++ b/skills/software-security/rules/codeguard-0-client-side-web-security.md
@@ -1,6 +1,5 @@
 ---
-description: Client-side web security (XSS/DOM XSS, CSP, CSRF, clickjacking, XS-Leaks,
-  third-party JS)
+description: Client-side web security (XSS/DOM XSS, CSP, CSRF, clickjacking, XS-Leaks, third-party JS)
 languages:
 - c
 - html

--- a/skills/software-security/rules/codeguard-0-cloud-orchestration-kubernetes.md
+++ b/skills/software-security/rules/codeguard-0-cloud-orchestration-kubernetes.md
@@ -1,6 +1,5 @@
 ---
-description: Kubernetes hardening (RBAC, admission policies, network policies, secrets,
-  supply chain)
+description: Kubernetes hardening (RBAC, admission policies, network policies, secrets, supply chain)
 languages:
 - javascript
 - yaml

--- a/skills/software-security/rules/codeguard-0-data-storage.md
+++ b/skills/software-security/rules/codeguard-0-data-storage.md
@@ -1,6 +1,5 @@
 ---
-description: Data & storage security (DB isolation, TLS, least privilege, RLS/CLS,
-  backups, auditing)
+description: Data & storage security (DB isolation, TLS, least privilege, RLS/CLS, backups, auditing)
 languages:
 - c
 - javascript

--- a/skills/software-security/rules/codeguard-0-devops-ci-cd-containers.md
+++ b/skills/software-security/rules/codeguard-0-devops-ci-cd-containers.md
@@ -1,6 +1,5 @@
 ---
-description: DevOps, CI/CD, and containers (pipeline hardening, artifacts, Docker/K8s
-  images, virtual patching, toolchain)
+description: DevOps, CI/CD, and containers (pipeline hardening, artifacts, Docker/K8s images, virtual patching, toolchain)
 languages:
 - docker
 - javascript

--- a/skills/software-security/rules/codeguard-0-file-handling-and-uploads.md
+++ b/skills/software-security/rules/codeguard-0-file-handling-and-uploads.md
@@ -1,6 +1,5 @@
 ---
-description: Secure file handling & uploads (validation, storage isolation, scanning,
-  safe delivery)
+description: Secure file handling & uploads (validation, storage isolation, scanning, safe delivery)
 languages:
 - c
 - go

--- a/skills/software-security/rules/codeguard-0-framework-and-languages.md
+++ b/skills/software-security/rules/codeguard-0-framework-and-languages.md
@@ -1,6 +1,5 @@
 ---
-description: Framework & language security guides (Django/DRF, Laravel/Symfony/Rails,
-  .NET, Java/JAAS, Node.js, PHP config)
+description: Framework & language security guides (Django/DRF, Laravel/Symfony/Rails, .NET, Java/JAAS, Node.js, PHP config)
 languages:
 - c
 - java

--- a/skills/software-security/rules/codeguard-0-input-validation-injection.md
+++ b/skills/software-security/rules/codeguard-0-input-validation-injection.md
@@ -1,6 +1,5 @@
 ---
-description: Input validation and injection defense (SQL/LDAP/OS), parameterization,
-  prototype pollution
+description: Input validation and injection defense (SQL/LDAP/OS), parameterization, prototype pollution
 languages:
 - c
 - go

--- a/skills/software-security/rules/codeguard-0-logging.md
+++ b/skills/software-security/rules/codeguard-0-logging.md
@@ -1,6 +1,5 @@
 ---
-description: Logging & monitoring (structured telemetry, redaction, integrity, detection
-  & alerting)
+description: Logging & monitoring (structured telemetry, redaction, integrity, detection & alerting)
 languages:
 - c
 - javascript

--- a/skills/software-security/rules/codeguard-0-mobile-apps.md
+++ b/skills/software-security/rules/codeguard-0-mobile-apps.md
@@ -1,6 +1,5 @@
 ---
-description: 'Mobile app security (iOS/Android): storage, transport, code integrity,
-  biometrics, permissions'
+description: 'Mobile app security (iOS/Android): storage, transport, code integrity, biometrics, permissions'
 languages:
 - java
 - javascript

--- a/skills/software-security/rules/codeguard-0-privacy-data-protection.md
+++ b/skills/software-security/rules/codeguard-0-privacy-data-protection.md
@@ -1,6 +1,5 @@
 ---
-description: Privacy & data protection (minimization, classification, encryption,
-  rights, transparency)
+description: Privacy & data protection (minimization, classification, encryption, rights, transparency)
 languages:
 - javascript
 - matlab

--- a/skills/software-security/rules/codeguard-0-session-management-and-cookies.md
+++ b/skills/software-security/rules/codeguard-0-session-management-and-cookies.md
@@ -1,6 +1,5 @@
 ---
-description: Session management and secure cookies (rotation, fixation, timeouts,
-  theft detection)
+description: Session management and secure cookies (rotation, fixation, timeouts, theft detection)
 languages:
 - c
 - go

--- a/skills/software-security/rules/codeguard-0-supply-chain-security.md
+++ b/skills/software-security/rules/codeguard-0-supply-chain-security.md
@@ -1,6 +1,5 @@
 ---
-description: Dependency & supply chain security (pinning, SBOM, provenance, integrity,
-  private registries)
+description: Dependency & supply chain security (pinning, SBOM, provenance, integrity, private registries)
 languages:
 - docker
 - javascript

--- a/skills/software-security/rules/codeguard-0-xml-and-serialization.md
+++ b/skills/software-security/rules/codeguard-0-xml-and-serialization.md
@@ -1,6 +1,5 @@
 ---
-description: XML security and safe deserialization (DTD/XXE hardening, schema validation,
-  no unsafe native deserialization)
+description: XML security and safe deserialization (DTD/XXE hardening, schema validation, no unsafe native deserialization)
 languages:
 - c
 - go

--- a/src/formats/base.py
+++ b/src/formats/base.py
@@ -140,6 +140,7 @@ class BaseFormat(ABC):
                 {field_name: value},
                 default_flow_style=False,
                 allow_unicode=True,
+                width=float("inf")
             )
             return yaml_dump.strip()
         return ""

--- a/src/formats/copilot.py
+++ b/src/formats/copilot.py
@@ -51,7 +51,6 @@ class CopilotFormat(BaseFormat):
 
         # Add description
         description = self._format_yaml_field("description", rule.description)
-        description = description.replace('\n', '')
         if description:
             yaml_lines.append(description)
 


### PR DESCRIPTION
Changed the `title` field in the Copilot instructions to `description` to match the format expected by Copilot.  This change supposedly enables the description to show when you hover over the file in an agent chat.

Reference: https://code.visualstudio.com/docs/copilot/customization/custom-instructions#_instructions-file-format

Also changed to `yaml.safe_dump` just to be safe, and changed the `width` parameter to `float("inf")` to prevent new lines from being thrown into the description field, potentially messing with parsing.

Generated new rules from changes.