### PR TITLE
Update mkdocs.yml to remove extra footer

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,3 +55,7 @@ markdown_extensions:
   - pymdownx.keys
   - pymdownx.tabbed:
       alternate_style: true
+      
+extra:
+  generator: false
+


### PR DESCRIPTION
This pull request introduces a minor configuration update to the `mkdocs.yml` file. The change disables the documentation generator by setting the `generator` option to `false`.

- Configuration update:
  * [`mkdocs.yml`](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R58-R61): Added `extra.generator: false` to prevent generator metadata from being included in the documentation output.