### PR TITLE
Add Antigravity to CI workflows, docs, and fix CONTRIBUTING.md link

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-rule.yml
+++ b/.github/ISSUE_TEMPLATE/new-rule.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for your new rule request! Please provide as much detail as possible. Use any of the existing rules as a reference. You only have to provide the rule contents (markdown), not the rule metadata. We will handle the rest. In other words, convert your rule into all the formats (Cursor, Windsurf, Copilot).
+        Thank you for your new rule request! Please provide as much detail as possible. Use any of the existing rules as a reference. You only have to provide the rule contents (markdown), not the rule metadata. We will handle the rest. In other words, convert your rule into all the formats (Cursor, Windsurf, Copilot, Antigravity).
 
   - type: textarea
     id: description

--- a/.github/ISSUE_TEMPLATE/rule-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/rule-feedback.yml
@@ -26,6 +26,7 @@ body:
         - Cursor
         - GitHub Copilot
         - Windsurf
+        - Antigravity
         - Codex
         - Augment Code
         - Sourcegraph

--- a/.github/workflows/build-ide-bundles.yml
+++ b/.github/workflows/build-ide-bundles.yml
@@ -54,6 +54,7 @@ jobs:
           zip -r ../ide-rules-cursor.zip .cursor/
           zip -r ../ide-rules-windsurf.zip .windsurf/
           zip -r ../ide-rules-copilot.zip .github/
+          zip -r ../ide-rules-antigravity.zip .agent/
           cd ..
           zip -r ide-rules-all.zip dist/
           ls -lh ide-rules-*.zip
@@ -67,5 +68,6 @@ jobs:
             ide-rules-cursor.zip \
             ide-rules-windsurf.zip \
             ide-rules-copilot.zip \
+            ide-rules-antigravity.zip \
             --clobber
 

--- a/.github/workflows/validate-rules.yml
+++ b/.github/workflows/validate-rules.yml
@@ -89,6 +89,11 @@ jobs:
             exit 1
           fi
           
+          if [ ! -d "test-output/.agent" ]; then
+            echo "❌ Antigravity rules not generated"
+            exit 1
+          fi
+          
           echo "✅ All IDE formats generated successfully"
 
       - name: Check skills/ directory is up-to-date

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,7 +160,7 @@ git push origin main
 
 **Note**: The conversion script automatically syncs the version from `pyproject.toml` to:
 - `.claude-plugin/plugin.json` and `marketplace.json` (Claude Code plugin metadata)
-- All generated IDE rule files (Cursor `.mdc`, Windsurf `.md`, Copilot `.instructions.md`, Claude Code `.md`)
+- All generated IDE rule files (Cursor `.mdc`, Windsurf `.md`, Copilot `.instructions.md`, Claude Code `.md`, Antigravity `.md`)
 
 This ensures version consistency across all artifacts.
 
@@ -174,7 +174,7 @@ This ensures version consistency across all artifacts.
 
 GitHub Actions will automatically:
 - ✅ Validate versions match the tag
-- ✅ Build IDE bundles (Cursor, Windsurf, Copilot)
+- ✅ Build IDE bundles (Cursor, Windsurf, Copilot, Antigravity)
 - ✅ Upload ZIP artifacts to the release
 
 ## Testing Your Changes

--- a/docs/claude-code-skill-plugin.md
+++ b/docs/claude-code-skill-plugin.md
@@ -290,7 +290,7 @@ uv run python src/convert_to_ide_formats.py
 This command:
 - Converts unified rules from `sources/` to IDE-specific formats
 - Generates `skills/` directory with the 22 core security rules (Claude Code plugin)
-- Creates `dist/` with IDE-specific formats (Cursor, Windsurf, Copilot)
+- Creates `dist/` with IDE-specific formats (Cursor, Windsurf, Copilot, Antigravity)
 
 **Note:** The Claude Code plugin (`skills/`) always contains only the 22 curated core rules. To build bundles with OWASP supplementary rules for other IDEs, use `--source core owasp`, but this only affects `dist/`, not `skills/`.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -50,19 +50,19 @@ This FAQ document provides clear, concise answers to help developers seamlessly 
 
 ## Q: How can I use the rules in my own AI agent?
 
-**A:** You can use the rules in your own AI agent by creating a custom ruleset. You can create a custom ruleset by creating a new file in the `.cursor/rules`, `.windsurf/rules`, or `.github/instructions` directories and adding the rules you want to apply. You can also use the `project-codeguard/rules` repository as a template to create your own ruleset.
+**A:** You can use the rules in your own AI agent by creating a custom ruleset. You can create a custom ruleset by creating a new file in the `.cursor/rules`, `.windsurf/rules`, `.github/instructions`, or `.agent/rules` directories and adding the rules you want to apply. You can also use the `project-codeguard/rules` repository as a template to create your own ruleset.
 
 ---
 
 ## Q: Why does the downloaded release folder appear empty?
 
-**A:** After downloading and extracting the release, the folders may appear empty because the rule directories (`.cursor/`, `.windsurf/`, `.github/`) start with a dot (`.`) and are hidden by default on most operating systems.
+**A:** After downloading and extracting the release, the folders may appear empty because the rule directories (`.cursor/`, `.windsurf/`, `.github/`, `.agent/`) start with a dot (`.`) and are hidden by default on most operating systems.
 
 **To show hidden files:**
 
 === "macOS"
     
-    In Finder, navigate to the extracted folder and press ++cmd+shift+period++ to toggle the visibility of hidden files. You should now see the `.cursor/`, `.windsurf/`, and `.github/` directories.
+    In Finder, navigate to the extracted folder and press ++cmd+shift+period++ to toggle the visibility of hidden files. You should now see the `.cursor/`, `.windsurf/`, `.github/`, and `.agent/` directories.
 
 === "Windows"
     
@@ -76,7 +76,7 @@ This FAQ document provides clear, concise answers to help developers seamlessly 
     
     In your file manager, press ++ctrl+h++ to toggle hidden files, or use `ls -la` in the terminal to view all files including hidden ones.
 
-Once hidden files are visible, you can copy the appropriate directory (`.cursor/`, `.windsurf/`, or `.github/`) to your project root.
+Once hidden files are visible, you can copy the appropriate directory (`.cursor/`, `.windsurf/`, `.github/`, or `.agent/`) to your project root.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -45,11 +45,13 @@ Before you begin, familiarize yourself with how rules work in your IDE:
     - `ide-rules-cursor.zip` - Cursor only
     - `ide-rules-windsurf.zip` - Windsurf only
     - `ide-rules-copilot.zip` - GitHub Copilot only
+    - `ide-rules-antigravity.zip` - Antigravity only
 2. **Extract**: Unzip the downloaded file
 3. **Install**: Copy the relevant IDE-specific rules to your project root:
     - For **Cursor**: Copy `.cursor/` directory to your project
     - For **Windsurf**: Copy `.windsurf/` directory to your project
     - For **GitHub Copilot**: Copy `.github/` directory to your project
+    - For **Antigravity**: Copy `.agent/` directory to your project
 
 
 !!! tip "Repository Level Installation"
@@ -165,7 +167,7 @@ To verify the rules are working:
 - **Review Rules**: Explore the security rules in your IDE's rules directory
 - **Test Integration**: Generate some code and see the security guidance in action
 - **Share Feedback**: Help us improve by [opening an issue](https://github.com/project-codeguard/rules/issues)
-- **Contribute**: See [CONTRIBUTING.md](https://github.com/project-codeguard/rules/CONTRIBUTING.md) to contribute new rules or improvements
+- **Contribute**: See [CONTRIBUTING.md](https://github.com/project-codeguard/rules/blob/main/CONTRIBUTING.md) to contribute new rules or improvements
 
 !!! success "You're Ready!"
     Project CodeGuard is now protecting your development workflow. The security rules will automatically guide AI assistants to generate more secure code.


### PR DESCRIPTION
## Summary

Follow-up to Antigravity format PR. Adds Antigravity to CI, templates, and docs.

## Changes

- CI: Add `.agent` validation and `ide-rules-antigravity.zip` to releases
- Templates: Add Antigravity to issue dropdowns
- Docs: Add Antigravity to all IDE listings
- Fix: Broken CONTRIBUTING.md link

Fixes #78 #80 